### PR TITLE
Retire phpunit 10, migrate test metadata to attributes, add dependabot

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: clover.xml
-json_path: coveralls-upload.json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+
+# Security updates run without this file; scheduled version updates do not.
+# Groups mirror the track-admin house style, trimmed to what these forks contain
+# (no npm, and no private registry — the sibling forks are public VCS repositories).
+# Monthly rather than weekly: these forks are not actively maintained between PHP hops.
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "11:00"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10
+    groups:
+      laminas-api-tools:
+        patterns:
+          - "laminas-api-tools/*"
+      laminas:
+        patterns:
+          - "laminas/*"
+      doctrine:
+        patterns:
+          - "doctrine/*"
+      test-tooling:
+        patterns:
+          - "phpunit/*"
+          - "sebastian/*"
+          - "phpspec/*"
+      static-analysis:
+        patterns:
+          - "vimeo/psalm"
+          - "psalm/*"
+          - "squizlabs/*"
+          - "slevomat/*"
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "11:00"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /coveralls-upload.json
 /phpunit.xml
 /vendor/
+/.phpunit.cache/
 /.phpunit.result.cache
 /.phpcs-cache

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         }
     },
     "require": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "container-interop/container-interop": "^1.2",
         "laminas-api-tools/api-tools-api-problem": "^1.10",
         "laminas/laminas-eventmanager": "^3.15",
@@ -43,15 +42,16 @@
         "laminas/laminas-servicemanager": "^3.24",
         "laminas/laminas-stdlib": "^3.21",
         "laminas/laminas-validator": "^2.65",
-        "laminas/laminas-view": "^2.43"
+        "laminas/laminas-view": "^2.43",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
     },
     "require-dev": {
         "laminas-api-tools/api-tools-hal": "^1.13",
-        "laminas/laminas-coding-standard": "^3",
+        "laminas/laminas-coding-standard": "^3.1",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^10",
+        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
         "psalm/plugin-phpunit": "^0.19",
-        "vimeo/psalm": "^6.0"
+        "vimeo/psalm": "^6.14"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2d5ade3eb7cd308337be12267976d91",
+    "content-hash": "5929903e58dd89e0c23989c59406341d",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -4088,35 +4088,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.16",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "sebastian/code-unit-reverse-lookup": "^3.0.0",
-                "sebastian/complexity": "^3.2.0",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/lines-of-code": "^2.0.2",
-                "sebastian/version": "^4.0.1",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^11.5.46"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -4125,7 +4125,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1.x-dev"
+                    "dev-main": "11.0.x-dev"
                 }
             },
             "autoload": {
@@ -4154,40 +4154,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-22T04:31:57+00:00"
+            "time": "2025-12-24T07:01:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -4215,36 +4227,48 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2026-02-02T13:52:54+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -4252,7 +4276,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4278,7 +4302,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
             },
             "funding": [
                 {
@@ -4286,32 +4311,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2024-07-03T05:07:44+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4338,7 +4363,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
             },
             "funding": [
                 {
@@ -4346,32 +4371,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2024-07-03T05:08:43+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4397,7 +4422,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
             },
             "funding": [
                 {
@@ -4405,20 +4431,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2024-07-03T05:09:35+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.64",
+            "version": "11.5.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
-                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
                 "shasum": ""
             },
             "require": {
@@ -4431,23 +4457,24 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.16",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-invoker": "^4.0.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "phpunit/php-timer": "^6.0.0",
-                "sebastian/cli-parser": "^2.0.1",
-                "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.5",
-                "sebastian/diff": "^5.1.1",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.4",
-                "sebastian/global-state": "^6.0.2",
-                "sebastian/object-enumerator": "^5.0.0",
-                "sebastian/recursion-context": "^5.0.1",
-                "sebastian/type": "^4.0.0",
-                "sebastian/version": "^4.0.1"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -4458,7 +4485,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -4490,7 +4517,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
             },
             "funding": [
                 {
@@ -4498,7 +4525,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-07-06T14:50:35+00:00"
+            "time": "2026-07-06T14:52:39+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4793,28 +4820,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4838,7 +4865,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
             },
             "funding": [
                 {
@@ -4846,32 +4873,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:12:49+00:00"
+            "time": "2024-07-03T04:41:36+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4894,7 +4921,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
             },
             "funding": [
                 {
@@ -4902,32 +4930,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2025-03-19T07:56:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4949,7 +4977,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
             },
             "funding": [
                 {
@@ -4957,36 +4986,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2024-07-03T04:45:54+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.5",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
-                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -5026,7 +5058,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
             },
             "funding": [
                 {
@@ -5046,33 +5078,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:25:16+00:00"
+            "time": "2026-01-24T09:26:40+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.2.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5096,7 +5128,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
             },
             "funding": [
                 {
@@ -5104,33 +5136,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:37:17+00:00"
+            "time": "2024-07-03T04:49:50+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "symfony/process": "^6.4"
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5163,7 +5195,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
             },
             "funding": [
                 {
@@ -5171,27 +5203,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:15:17+00:00"
+            "time": "2024-07-03T04:53:05+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.1.0",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -5199,7 +5231,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-main": "7.2-dev"
                 }
             },
             "autoload": {
@@ -5227,42 +5259,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-23T08:47:14+00:00"
+            "time": "2025-05-21T11:55:47+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.4",
+            "version": "6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
-                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -5305,7 +5349,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
             },
             "funding": [
                 {
@@ -5325,35 +5369,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:09:11+00:00"
+            "time": "2025-09-24T06:12:51+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.2",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -5379,7 +5423,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
             },
             "funding": [
                 {
@@ -5387,33 +5431,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:19:19+00:00"
+            "time": "2024-07-03T04:57:36+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5437,7 +5481,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
             },
             "funding": [
                 {
@@ -5445,34 +5489,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:38:20+00:00"
+            "time": "2024-07-03T04:58:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5494,7 +5538,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -5502,32 +5547,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2024-07-03T05:00:13+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5549,7 +5594,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
             },
             "funding": [
                 {
@@ -5557,32 +5603,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2024-07-03T05:01:32+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
-                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -5613,7 +5659,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
             },
             "funding": [
                 {
@@ -5633,32 +5679,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:50:56+00:00"
+            "time": "2025-08-13T04:42:22+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "4.0.0",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -5681,37 +5727,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2025-08-09T06:55:48+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -5734,7 +5793,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
             },
             "funding": [
                 {
@@ -5742,7 +5802,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -5879,16 +5939,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -5954,20 +6014,72 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v7.4.15",
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930"
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/088ec6fe0ef6819cbc301174093b6bfa4ad26930",
-                "reference": "088ec6fe0ef6819cbc301174093b6bfa4ad26930",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d",
                 "shasum": ""
             },
             "require": {
@@ -6032,7 +6144,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.15"
+                "source": "https://github.com/symfony/console/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -6052,7 +6164,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-27T13:51:00+00:00"
+            "time": "2026-07-31T12:37:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10,9 +10,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AcceptFilterListener]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function onRoute(MvcEvent $e)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$headers]]></code>
       <code><![CDATA[$headers]]></code>
@@ -99,11 +96,6 @@
     <InvalidArgument>
       <code><![CDATA[$options]]></code>
     </InvalidArgument>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __get($key)]]></code>
-      <code><![CDATA[public function __set($key, $value)]]></code>
-      <code><![CDATA[public function setFromArray($options)]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[ContentNegotiationOptions]]></code>
     </MissingTemplateParam>
@@ -141,9 +133,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/ContentTypeFilterListener.php">
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function attach(EventManagerInterface $events, $priority = 1)]]></code>
-    </MissingOverrideAttribute>
     <MixedArrayOffset>
       <code><![CDATA[$this->config[$controllerName]]]></code>
     </MixedArrayOffset>
@@ -475,10 +464,6 @@
     <DeprecatedMethod>
       <code><![CDATA[getServiceLocator]]></code>
     </DeprecatedMethod>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$container->get('Request')]]></code>
     </MixedArgument>
@@ -515,10 +500,6 @@
       <code><![CDATA[getServiceLocator]]></code>
       <code><![CDATA[getServiceLocator]]></code>
     </DeprecatedMethod>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)]]></code>
-      <code><![CDATA[public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$container->get('Request')]]></code>
     </MixedArgument>
@@ -546,9 +527,6 @@
     <DocblockTypeContradiction>
       <code><![CDATA[null === $this->request]]></code>
     </DocblockTypeContradiction>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function moveUploadedFile($sourceFile, $targetFile)]]></code>
-    </MissingOverrideAttribute>
     <MissingTemplateParam>
       <code><![CDATA[RenameUpload]]></code>
     </MissingTemplateParam>
@@ -560,9 +538,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[HttpMethodOverrideListener]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function attach(EventManagerInterface $events, $priority = 1)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$allowedMethods]]></code>
       <code><![CDATA[$overrideMethod]]></code>
@@ -605,15 +580,10 @@
       <code><![CDATA[BaseJsonModel]]></code>
     </InvalidExtendClass>
     <MethodSignatureMismatch>
-      <code><![CDATA[public function serialize()]]></code>
-      <code><![CDATA[public function setTerminal($flag)]]></code>
-      <code><![CDATA[public function setVariables($variables, $overwrite = false)]]></code>
+      <code><![CDATA[#[Override]]]></code>
+      <code><![CDATA[#[Override]]]></code>
+      <code><![CDATA[#[Override]]]></code>
     </MethodSignatureMismatch>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function serialize()]]></code>
-      <code><![CDATA[public function setTerminal($flag)]]></code>
-      <code><![CDATA[public function setVariables($variables, $overwrite = false)]]></code>
-    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$variables]]></code>
       <code><![CDATA[$variables]]></code>
@@ -771,11 +741,8 @@
       <code><![CDATA[BaseValidator]]></code>
     </InvalidExtendClass>
     <MethodSignatureMismatch>
-      <code><![CDATA[public function isValid($value)]]></code>
+      <code><![CDATA[#[Override]]]></code>
     </MethodSignatureMismatch>
-    <MissingOverrideAttribute>
-      <code><![CDATA[public function isValid($value)]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
@@ -796,9 +763,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AcceptFilterListenerTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedMethodCall>
       <code><![CDATA[willReturn]]></code>
     </MixedMethodCall>
@@ -820,9 +784,6 @@
       <code><![CDATA[$response->getApiProblem()->detail]]></code>
       <code><![CDATA[$response->getApiProblem()->status]]></code>
     </InaccessibleProperty>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$response->getApiProblem()->detail]]></code>
     </MixedArgument>
@@ -844,9 +805,6 @@
     <InaccessibleProperty>
       <code><![CDATA[$response->getApiProblem()->detail]]></code>
     </InaccessibleProperty>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$response->getApiProblem()->detail]]></code>
     </MixedArgument>
@@ -874,9 +832,6 @@
     <InvalidDocblock>
       <code><![CDATA[public static function multipartFormDataMethods(): array]]></code>
     </InvalidDocblock>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$details['detail']]]></code>
       <code><![CDATA[$file['tmp_name']]]></code>
@@ -1054,9 +1009,6 @@
       <code><![CDATA[getTarget]]></code>
       <code><![CDATA[getTarget]]></code>
     </DeprecatedMethod>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/Filter/RenameUploadTest.php">
     <ClassMustBeFinal>
@@ -1065,10 +1017,6 @@
     <DeprecatedClass>
       <code><![CDATA[new RenameUpload($target)]]></code>
     </DeprecatedClass>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-      <code><![CDATA[protected function tearDown(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
   <file src="test/HttpMethodOverrideListenerTest.php">
     <ClassMustBeFinal>
@@ -1080,9 +1028,6 @@
       <code><![CDATA[$problem->status]]></code>
       <code><![CDATA[$problem->status]]></code>
     </InaccessibleProperty>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$problem->detail]]></code>
       <code><![CDATA[$problem->detail]]></code>
@@ -1117,9 +1062,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[RequestTest]]></code>
     </ClassMustBeFinal>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
     <PossiblyFalseOperand>
       <code><![CDATA[realpath(__FILE__)]]></code>
       <code><![CDATA[realpath(__FILE__)]]></code>
@@ -1138,8 +1080,5 @@
       <code><![CDATA[UploadFile]]></code>
       <code><![CDATA[new UploadFile()]]></code>
     </DeprecatedClass>
-    <MissingOverrideAttribute>
-      <code><![CDATA[protected function setUp(): void]]></code>
-    </MissingOverrideAttribute>
   </file>
 </files>

--- a/src/AcceptFilterListener.php
+++ b/src/AcceptFilterListener.php
@@ -8,6 +8,7 @@ use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 use Laminas\Http\Headers as HttpHeaders;
 use Laminas\Mvc\MvcEvent;
+use Override;
 
 use function is_array;
 use function is_string;
@@ -20,6 +21,7 @@ class AcceptFilterListener extends ContentTypeFilterListener
      *
      * @return null|ApiProblemResponse
      */
+    #[Override]
     public function onRoute(MvcEvent $e)
     {
         if (empty($this->config)) {

--- a/src/ContentNegotiationOptions.php
+++ b/src/ContentNegotiationOptions.php
@@ -6,6 +6,7 @@ namespace Laminas\ApiTools\ContentNegotiation;
 
 use Laminas\Stdlib\AbstractOptions;
 use Laminas\Stdlib\Exception\BadMethodCallException;
+use Override;
 
 use function array_merge_recursive;
 use function str_replace;
@@ -45,6 +46,7 @@ class ContentNegotiationOptions extends AbstractOptions
      *
      * @see self::normalizeOptions
      */
+    #[Override]
     public function setFromArray($options)
     {
         return parent::setFromArray(
@@ -117,6 +119,7 @@ class ContentNegotiationOptions extends AbstractOptions
      * @throws BadMethodCallException
      * @return void
      */
+    #[Override]
     public function __set($key, $value)
     {
         parent::__set($this->normalizeKey($key), $value);
@@ -135,6 +138,7 @@ class ContentNegotiationOptions extends AbstractOptions
      * @throws BadMethodCallException
      * @return mixed
      */
+    #[Override]
     public function __get($key)
     {
         return parent::__get($this->normalizeKey($key));

--- a/src/ContentTypeFilterListener.php
+++ b/src/ContentTypeFilterListener.php
@@ -10,6 +10,7 @@ use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\ArrayUtils;
+use Override;
 
 use function method_exists;
 
@@ -25,6 +26,7 @@ class ContentTypeFilterListener extends AbstractListenerAggregate
     /**
      * @param int                    $priority
      */
+    #[Override]
     public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, [$this, 'onRoute'], -625);

--- a/src/Factory/RenameUploadFilterFactory.php
+++ b/src/Factory/RenameUploadFilterFactory.php
@@ -9,6 +9,7 @@ use Laminas\ApiTools\ContentNegotiation\Filter\RenameUpload;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 
 class RenameUploadFilterFactory implements FactoryInterface
 {
@@ -24,6 +25,7 @@ class RenameUploadFilterFactory implements FactoryInterface
      * @param null|array $options
      * @return RenameUpload
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $filter = new RenameUpload($options);
@@ -42,6 +44,7 @@ class RenameUploadFilterFactory implements FactoryInterface
      * @param null|string $requestedName
      * @return RenameUpload
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
     {
         $requestedName = $requestedName ?: RenameUpload::class;

--- a/src/Factory/UploadFileValidatorFactory.php
+++ b/src/Factory/UploadFileValidatorFactory.php
@@ -9,6 +9,7 @@ use Laminas\ApiTools\ContentNegotiation\Validator\UploadFile;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Override;
 
 use function method_exists;
 
@@ -29,6 +30,7 @@ class UploadFileValidatorFactory implements FactoryInterface
      * @param array<string, mixed>|null $options
      * @return UploadFile
      */
+    #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         if (
@@ -52,6 +54,7 @@ class UploadFileValidatorFactory implements FactoryInterface
      * @param null|string $requestedName
      * @return UploadFile
      */
+    #[Override]
     public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
     {
         $requestedName = $requestedName ?: UploadFile::class;

--- a/src/Filter/RenameUpload.php
+++ b/src/Filter/RenameUpload.php
@@ -8,6 +8,7 @@ use Laminas\Filter\Exception\RuntimeException as FilterRuntimeException;
 use Laminas\Filter\File\RenameUpload as BaseFilter;
 use Laminas\Stdlib\ErrorHandler;
 use Laminas\Stdlib\RequestInterface;
+use Override;
 
 use function method_exists;
 use function rename;
@@ -41,6 +42,7 @@ class RenameUpload extends BaseFilter
      * @return bool
      * @throws FilterRuntimeException In the event of a warning.
      */
+    #[Override]
     protected function moveUploadedFile($sourceFile, $targetFile)
     {
         if (

--- a/src/HttpMethodOverrideListener.php
+++ b/src/HttpMethodOverrideListener.php
@@ -10,6 +10,7 @@ use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\MvcEvent;
+use Override;
 
 use function array_key_exists;
 use function in_array;
@@ -31,6 +32,7 @@ class HttpMethodOverrideListener extends AbstractListenerAggregate
      *
      * @param int                   $priority
      */
+    #[Override]
     public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, [$this, 'onRoute'], -40);

--- a/src/JsonModel.php
+++ b/src/JsonModel.php
@@ -9,6 +9,7 @@ use Laminas\ApiTools\Hal\Collection as HalCollection;
 use Laminas\ApiTools\Hal\Entity as HalEntity;
 use Laminas\Json\Json;
 use Laminas\View\Model\JsonModel as BaseJsonModel;
+use Override;
 
 use function json_last_error;
 use function method_exists;
@@ -37,6 +38,7 @@ class JsonModel extends BaseJsonModel
      * @param  bool $overwrite
      * @return self
      */
+    #[Override]
     public function setVariables($variables, $overwrite = false)
     {
         if (
@@ -55,6 +57,7 @@ class JsonModel extends BaseJsonModel
      * @param  bool $flag
      * @return self
      */
+    #[Override]
     public function setTerminal($flag)
     {
         // Do nothing; should always terminate
@@ -74,6 +77,7 @@ class JsonModel extends BaseJsonModel
      *
      * @return string
      */
+    #[Override]
     public function serialize()
     {
         $variables = $this->getVariables();

--- a/src/Validator/UploadFile.php
+++ b/src/Validator/UploadFile.php
@@ -6,6 +6,7 @@ namespace Laminas\ApiTools\ContentNegotiation\Validator;
 
 use Laminas\Stdlib\RequestInterface;
 use Laminas\Validator\File\UploadFile as BaseValidator;
+use Override;
 
 use function count;
 use function method_exists;
@@ -33,6 +34,7 @@ class UploadFile extends BaseValidator
      * @param mixed $value
      * @return bool
      */
+    #[Override]
     public function isValid($value)
     {
         if (

--- a/test/AcceptFilterListenerTest.php
+++ b/test/AcceptFilterListenerTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\ApiTools\ContentNegotiation;
 
 use Laminas\ApiTools\ContentNegotiation\AcceptFilterListener;
 use Laminas\Http\Headers;
+use Override;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionMethod;
@@ -17,14 +19,13 @@ class AcceptFilterListenerTest extends TestCase
     /** @var AcceptFilterListener */
     protected $listener;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->listener = new AcceptFilterListener();
     }
 
-    /**
-     * @group 58
-     */
+    #[Group('58')]
     public function testMissingAcceptHeaderIndicatesValidMediaType(): void
     {
         $headers = $this->prophesize(Headers::class);

--- a/test/AcceptListenerTest.php
+++ b/test/AcceptListenerTest.php
@@ -15,6 +15,8 @@ use Laminas\Stdlib\RequestInterface;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ModelInterface;
 use LaminasTest\ApiTools\ContentNegotiation\TestAsset\ContentTypeController;
+use Override;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 class AcceptListenerTest extends TestCase
@@ -30,6 +32,7 @@ class AcceptListenerTest extends TestCase
     /** @var ContentTypeController */
     protected $controller;
 
+    #[Override]
     protected function setUp(): void
     {
         $plugins = new ControllerPluginManager(new ServiceManager());
@@ -85,9 +88,7 @@ class AcceptListenerTest extends TestCase
         $this->assertInstanceOf(ModelInterface::class, $result);
     }
 
-    /**
-     * @group 22
-     */
+    #[Group('22')]
     public function testShouldExitEarlyIfNonHttpRequestPresentInEvent(): void
     {
         /** @var RequestInterface $request */

--- a/test/ContentNegotiationOptionsTest.php
+++ b/test/ContentNegotiationOptionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\ApiTools\ContentNegotiation;
 
 use Laminas\ApiTools\ContentNegotiation\ContentNegotiationOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ContentNegotiationOptionsTest extends TestCase
@@ -20,9 +21,7 @@ class ContentNegotiationOptionsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dashSeparatedOptions
-     */
+    #[DataProvider('dashSeparatedOptions')]
     public function testSetNormalizesDashSeparatedKeysToUnderscoreSeparated(string $key, string $normalized): void
     {
         $options         = new ContentNegotiationOptions();
@@ -31,9 +30,7 @@ class ContentNegotiationOptionsTest extends TestCase
         $this->assertEquals(['value'], $options->{$normalized});
     }
 
-    /**
-     * @dataProvider dashSeparatedOptions
-     */
+    #[DataProvider('dashSeparatedOptions')]
     public function testConstructorAllowsDashSeparatedKeys(string $key, string $normalized): void
     {
         $options = new ContentNegotiationOptions([$key => ['value']]);
@@ -41,9 +38,7 @@ class ContentNegotiationOptionsTest extends TestCase
         $this->assertEquals(['value'], $options->{$normalized});
     }
 
-    /**
-     * @dataProvider dashSeparatedOptions
-     */
+    #[DataProvider('dashSeparatedOptions')]
     public function testDashAndUnderscoreSeparatedValuesGetMerged(string $key, string $normalized): void
     {
         $keyValue        = 'valueKey';

--- a/test/ContentTypeFilterListenerTest.php
+++ b/test/ContentTypeFilterListenerTest.php
@@ -9,6 +9,8 @@ use Laminas\ApiTools\ContentNegotiation\ContentTypeFilterListener;
 use Laminas\Http\Request;
 use Laminas\Mvc\MvcEvent;
 use LaminasTest\ApiTools\ContentNegotiation\TestAsset\ContentTypeController;
+use Override;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 class ContentTypeFilterListenerTest extends TestCase
@@ -21,6 +23,7 @@ class ContentTypeFilterListenerTest extends TestCase
     /** @var MvcEvent */
     protected $event;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->listener = new ContentTypeFilterListener();
@@ -66,9 +69,7 @@ class ContentTypeFilterListenerTest extends TestCase
         $this->assertStringContainsString('Invalid content-type', $response->getApiProblem()->detail);
     }
 
-    /**
-     * @group 66
-     */
+    #[Group('66')]
     public function testCastsObjectBodyContentToStringBeforeWorkingWithIt(): void
     {
         $contentType = 'application/vnd.laminas.v1.foo+json';

--- a/test/ContentTypeListenerTest.php
+++ b/test/ContentTypeListenerTest.php
@@ -13,6 +13,9 @@ use Laminas\EventManager\EventManagerInterface;
 use Laminas\Http\Request;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\Parameters;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
@@ -42,6 +45,7 @@ class ContentTypeListenerTest extends TestCase
     /** @var ContentTypeListener */
     protected $listener;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->listener = new ContentTypeListener();
@@ -58,10 +62,8 @@ class ContentTypeListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @group 3
-     * @dataProvider methodsWithBodies
-     */
+    #[Group('3')]
+    #[DataProvider('methodsWithBodies')]
     public function testJsonDecodeErrorsReturnsProblemResponse(string $method): void
     {
         $listener = $this->listener;
@@ -82,10 +84,8 @@ class ContentTypeListenerTest extends TestCase
         $this->assertStringContainsString('JSON decoding', $problem->detail);
     }
 
-    /**
-     * @group 3
-     * @dataProvider methodsWithBodies
-     */
+    #[Group('3')]
+    #[DataProvider('methodsWithBodies')]
     public function testJsonDecodeStringErrorsReturnsProblemResponse(string $method): void
     {
         $listener = $this->listener;
@@ -116,9 +116,7 @@ class ContentTypeListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider multipartFormDataMethods
-     */
+    #[DataProvider('multipartFormDataMethods')]
     public function testCanDecodeMultipartFormDataRequestsForPutPatchAndDeleteOperations(string $method): void
     {
         $request = new Request();
@@ -156,9 +154,7 @@ class ContentTypeListenerTest extends TestCase
         $this->assertTrue(file_exists($file['tmp_name']));
     }
 
-    /**
-     * @dataProvider multipartFormDataMethods
-     */
+    #[DataProvider('multipartFormDataMethods')]
     public function testCanDecodeMultipartFormDataRequestsFromStreamsForPutAndPatchOperations(string $method): void
     {
         $request = new ContentNegotiationRequest();
@@ -311,10 +307,8 @@ class ContentTypeListenerTest extends TestCase
         rmdir($tmpDir);
     }
 
-    /**
-     * @group 35
-     * @dataProvider methodsWithBodies
-     */
+    #[Group('35')]
+    #[DataProvider('methodsWithBodies')]
     public function testWillNotAttemptToInjectNullValueForBodyParams(string $method): void
     {
         $listener = $this->listener;
@@ -355,9 +349,9 @@ class ContentTypeListenerTest extends TestCase
 
     /**
      * @param mixed $content
-     * @group 36
-     * @dataProvider methodsWithBlankBodies
      */
+    #[Group('36')]
+    #[DataProvider('methodsWithBlankBodies')]
     public function testWillNotAttemptToInjectNullValueForBodyParamsWhenContentIsWhitespace(
         string $method,
         string $content
@@ -400,9 +394,9 @@ class ContentTypeListenerTest extends TestCase
 
     /**
      * @param mixed $content
-     * @group 36
-     * @dataProvider methodsWithLeadingWhitespace
      */
+    #[Group('36')]
+    #[DataProvider('methodsWithLeadingWhitespace')]
     public function testWillHandleJsonContentWithLeadingWhitespace(string $method, string $content): void
     {
         $listener = $this->listener;
@@ -443,9 +437,9 @@ class ContentTypeListenerTest extends TestCase
 
     /**
      * @param mixed $content
-     * @group 36
-     * @dataProvider methodsWithTrailingWhitespace
      */
+    #[Group('36')]
+    #[DataProvider('methodsWithTrailingWhitespace')]
     public function testWillHandleJsonContentWithTrailingWhitespace(string $method, string $content): void
     {
         $listener = $this->listener;
@@ -486,9 +480,9 @@ class ContentTypeListenerTest extends TestCase
 
     /**
      * @param mixed $content
-     * @group 36
-     * @dataProvider methodsWithLeadingAndTrailingWhitespace
      */
+    #[Group('36')]
+    #[DataProvider('methodsWithLeadingAndTrailingWhitespace')]
     public function testWillHandleJsonContentWithLeadingAndTrailingWhitespace(string $method, string $content): void
     {
         $listener = $this->listener;
@@ -521,8 +515,8 @@ class ContentTypeListenerTest extends TestCase
 
     /**
      * @param mixed $content
-     * @dataProvider methodsWithWhitespaceInsideBody
      */
+    #[DataProvider('methodsWithWhitespaceInsideBody')]
     public function testWillNotRemoveWhitespaceInsideBody(string $method, string $content): void
     {
         $listener = $this->listener;
@@ -542,9 +536,7 @@ class ContentTypeListenerTest extends TestCase
         $this->assertEquals(['foo' => 'bar foo'], $params->getBodyParams());
     }
 
-    /**
-     * @group 42
-     */
+    #[Group('42')]
     public function testReturns400ResponseWhenBodyPartIsMissingName(): void
     {
         $request = new Request();
@@ -598,10 +590,8 @@ class ContentTypeListenerTest extends TestCase
         ], $params);
     }
 
-    /**
-     * @group 50
-     * @dataProvider methodsWithBodies
-     */
+    #[Group('50')]
+    #[DataProvider('methodsWithBodies')]
     public function testMergesHalEmbeddedPropertiesIntoTopLevelObjectWhenDecodingHalJson(string $method): void
     {
         $data = [
@@ -656,9 +646,9 @@ class ContentTypeListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider methodsWithStringContent
      * @param string|int $key
      */
+    #[DataProvider('methodsWithStringContent')]
     public function testStringContentIsParsedCorrectlyToAnArray(string $method, string $data, $key): void
     {
         $listener = $this->listener;
@@ -713,9 +703,9 @@ class ContentTypeListenerTest extends TestCase
      * @see https://github.com/zfcampus/zf-content-negotiation/pull/94
      * @see https://github.com/zfcampus/zf-content-negotiation/pull/96
      *
-     * @dataProvider nonPostMethodsContent
      * @param array|object $expected Expected body params
      */
+    #[DataProvider('nonPostMethodsContent')]
     public function testMissingContentTypeHeaderResultsInParsingAsJsonIfInitialCharacterIndicatesObjectOrArray(
         string $method,
         string $data,

--- a/test/Factory/RenameUploadFilterFactoryTest.php
+++ b/test/Factory/RenameUploadFilterFactoryTest.php
@@ -8,6 +8,7 @@ use Laminas\ApiTools\ContentNegotiation\Factory\RenameUploadFilterFactory;
 use Laminas\Filter\File\RenameUpload;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\ServiceManager\ServiceManager;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class RenameUploadFilterFactoryTest extends TestCase
@@ -15,6 +16,7 @@ class RenameUploadFilterFactoryTest extends TestCase
     /** @var FilterPluginManager */
     protected $filters;
 
+    #[Override]
     protected function setUp(): void
     {
         $config        = [

--- a/test/Filter/RenameUploadTest.php
+++ b/test/Filter/RenameUploadTest.php
@@ -6,6 +6,8 @@ namespace Laminas\ApiTools\ContentNegotiation\Filter;
 
 use DirectoryIterator;
 use Laminas\Http\Request as HttpRequest;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -36,6 +38,7 @@ class RenameUploadTest extends TestCase
     /** @var string */
     protected $targetDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir    = sys_get_temp_dir() . '/api-tools-content-negotiation-filter';
@@ -47,6 +50,7 @@ class RenameUploadTest extends TestCase
         mkdir($this->targetDir);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         if (! is_dir($this->tmpDir)) {
@@ -115,9 +119,7 @@ class RenameUploadTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider uploadMethods
-     */
+    #[DataProvider('uploadMethods')]
     public function testMoveUploadedFileSucceedsOnPutAndPatchHttpRequests(string $method): void
     {
         $target  = $this->targetDir . DIRECTORY_SEPARATOR . 'uploaded.txt';

--- a/test/HttpMethodOverrideListenerTest.php
+++ b/test/HttpMethodOverrideListenerTest.php
@@ -8,6 +8,8 @@ use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 use Laminas\ApiTools\ContentNegotiation\HttpMethodOverrideListener;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\MvcEvent;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function sprintf;
@@ -34,6 +36,7 @@ class HttpMethodOverrideListenerTest extends TestCase
     /**
      * Set up test
      */
+    #[Override]
     protected function setUp(): void
     {
         $this->listener = new HttpMethodOverrideListener($this->httpMethodOverride);
@@ -51,9 +54,7 @@ class HttpMethodOverrideListenerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider httpMethods
-     */
+    #[DataProvider('httpMethods')]
     public function testHttpMethodOverrideListener(string $method): void
     {
         $listener = $this->listener;
@@ -70,9 +71,7 @@ class HttpMethodOverrideListenerTest extends TestCase
         $this->assertEquals($method, $request->getMethod());
     }
 
-    /**
-     * @dataProvider httpMethods
-     */
+    #[DataProvider('httpMethods')]
     public function testHttpMethodOverrideListenerReturnsProblemResponseForMethodNotInConfig(string $method): void
     {
         $listener = $this->listener;
@@ -94,9 +93,7 @@ class HttpMethodOverrideListenerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider httpMethods
-     */
+    #[DataProvider('httpMethods')]
     public function testHttpMethodOverrideListenerReturnsProblemResponseForIllegalOverrideValue(string $method): void
     {
         $listener = $this->listener;

--- a/test/JsonModelTest.php
+++ b/test/JsonModelTest.php
@@ -10,6 +10,7 @@ use Laminas\ApiTools\ContentNegotiation\Exception\InvalidJsonException;
 use Laminas\ApiTools\ContentNegotiation\JsonModel;
 use Laminas\ApiTools\Hal\Collection as HalCollection;
 use Laminas\ApiTools\Hal\Entity as HalEntity;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function json_decode;
@@ -69,9 +70,7 @@ class JsonModelTest extends TestCase
         $jsonModel->serialize();
     }
 
-    /**
-     * @group 17
-     */
+    #[Group('17')]
     public function testCanSerializeTraversables(): void
     {
         $variables = [

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\ApiTools\ContentNegotiation;
 
 use Laminas\ApiTools\ContentNegotiation\Request;
+use Override;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use ReflectionProperty;
@@ -18,6 +19,7 @@ class RequestTest extends TestCase
     /** @var Request */
     protected $request;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->request = new Request();

--- a/test/Validator/UploadFileTest.php
+++ b/test/Validator/UploadFileTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\ApiTools\ContentNegotiation\Validator;
 
 use Laminas\ApiTools\ContentNegotiation\Validator\UploadFile;
 use Laminas\Http\Request as HttpRequest;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -20,6 +22,7 @@ class UploadFileTest extends TestCase
     /** @var UploadFile */
     protected $validator;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->validator = new UploadFile();
@@ -34,9 +37,7 @@ class UploadFileTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider uploadMethods
-     */
+    #[DataProvider('uploadMethods')]
     public function testDoesNotMarkUploadFileAsInvalidForPutAndPatchHttpRequests(string $method): void
     {
         $request = new HttpRequest();


### PR DESCRIPTION
## Summary

Part of the post-8.5 cleanup cycle. **No version tag** — the cycle gets tagged once every repo is done.

## Tooling normalized

| tool | from | to |
| --- | --- | --- |
| `phpunit/phpunit` | `^10` | `^11.0 \|\| ^12.0 \|\| ^13.0` |
| `vimeo/psalm` | `^6.0` | `^6.14` |
| `laminas/laminas-coding-standard` | `^3` | `^3.1` |

## Test metadata → attributes (34 annotations, 9 files)

22 of them in `ContentTypeListenerTest` alone. **PHPUnit 12 stopped reading doc-comment metadata**, so widening the constraint without this would have silently dropped every data provider in the suite.

No removed phpunit APIs here — no `returnValue`, `returnValueMap`, `isType` or `getMockForAbstractClass` — so nothing beyond the metadata needed changing.

## Also

- 25 `#[Override]` attributes, clearing every `MissingOverrideAttribute` entry from the psalm baseline.
- Removed the tracked `.coveralls.yml`; added `/.phpunit.cache/` to `.gitignore`.
- Added `.github/dependabot.yml` on a **monthly** interval.

## Verification

With `config.platform.php` unset, `--prefer-lowest` and latest on both PHP — **158 tests, 374 assertions green on phpunit 11.5.50, 11.5.56 and 13.1.14**. psalm clean cold on the locked set.

## Known, pre-existing: phpcs fails on PHP 8.5

`ContentTypeListenerTest` trips the **phpcs 3.x tokenizer** on 8.5. Not addressed here, and not caused here — the same check against the pristine branch reports **51** errors where this branch reports **46**, so these changes reduce it slightly.

It stays invisible to CI, which runs phpcs only on the lowest PHP. The fix needs **phpcs 4, blocked upstream**: `squizlabs/php_codesniffer` isn't required directly anywhere, it arrives through `laminas-coding-standard`, and both 3.0.1 and 3.1.0 pin `^3.10`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Added support for PHP 8.2–8.5.
  * Updated development tooling and testing configurations.
  * Added automated monthly dependency and GitHub Actions update checks.
  * Improved handling of PHPUnit and PHP metadata using modern attributes.
  * Excluded PHPUnit cache files from version control.
  * Removed obsolete coverage-upload configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->