### PR TITLE
Use a test stub for the non-HTTP request double

### DIFF
--- a/test/AcceptListenerTest.php
+++ b/test/AcceptListenerTest.php
@@ -91,8 +91,7 @@ class AcceptListenerTest extends TestCase
     #[Group('22')]
     public function testShouldExitEarlyIfNonHttpRequestPresentInEvent(): void
     {
-        /** @var RequestInterface $request */
-        $request = $this->getMockBuilder(RequestInterface::class)->getMock();
+        $request = $this->createStub(RequestInterface::class);
         $this->event->setRequest($request);
 
         $listener = $this->listener;


### PR DESCRIPTION
## Summary

Part of the **mock-to-stub pass**. **No version tag.**

`testShouldExitEarlyIfNonHttpRequestPresentInEvent` needs a `RequestInterface` that *isn't* an HTTP request; it never configures an expectation on it. `createStub()` says that.

It also makes the preceding `/** @var RequestInterface $request */` redundant, so that goes too — `createStub()` already returns the interface type.

## Result

This was the **only** phpunit 13 notice in this repo. 158 tests / 374 assertions now run with *no issues at all* on 11.5.56 and 13.1.14. psalm and phpcs clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a non-HTTP request test to use a request stub.
  * Existing test behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->