### PR TITLE
Drop laminas-json and the ServiceManager v2 surface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,18 +32,17 @@
         }
     },
     "require": {
-        "container-interop/container-interop": "^1.2",
         "laminas-api-tools/api-tools-api-problem": "^1.10",
         "laminas/laminas-eventmanager": "^3.15",
         "laminas/laminas-filter": "^2.42",
         "laminas/laminas-http": "^2.23",
-        "laminas/laminas-json": "^3.8",
         "laminas/laminas-mvc": "^3.8",
         "laminas/laminas-servicemanager": "^3.24",
         "laminas/laminas-stdlib": "^3.21",
         "laminas/laminas-validator": "^2.65",
         "laminas/laminas-view": "^2.43",
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+        "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
         "laminas-api-tools/api-tools-hal": "^1.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5929903e58dd89e0c23989c59406341d",
+    "content-hash": "bc9540768a70dbffaaf73d97545994f4",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -57,11 +57,11 @@
         },
         {
             "name": "laminas-api-tools/api-tools-api-problem",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/datasage/api-tools-api-problem",
-                "reference": "38bc98c443c70cb0e12253e0e9acd6562f39f046"
+                "reference": "da8f2a19de7e745f7851a357e950bf8008dfe3f4"
             },
             "require": {
                 "ext-json": "*",
@@ -77,16 +77,16 @@
                 "zfcampus/zf-api-problem": "^1.3.0"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3",
+                "laminas/laminas-coding-standard": "^3.1",
                 "laminas/laminas-servicemanager": "^3.24",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^11.5 || ^12",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
                 "psalm/plugin-phpunit": "^0.19",
                 "shipmonk/composer-dependency-analyser": "^1.8",
                 "symfony/console": "^6 || ^7 || ^8",
                 "symfony/filesystem": "^6 || ^7 || ^8",
                 "symfony/string": "^6 || ^7 || ^8",
-                "vimeo/psalm": "^6"
+                "vimeo/psalm": "^6.14"
             },
             "type": "library",
             "extra": {
@@ -145,7 +145,7 @@
                 "chat": "https://laminas.dev/chat",
                 "forum": "https://discourse.laminas.dev"
             },
-            "time": "2026-08-05T14:54:49+00:00"
+            "time": "2026-08-08T12:45:49+00:00"
         },
         {
             "name": "laminas/laminas-config",
@@ -688,11 +688,11 @@
         },
         {
             "name": "laminas/laminas-mvc",
-            "version": "3.9.0",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/datasage/laminas-mvc",
-                "reference": "e313b42d44ed3821cf1a381180ac31b3029e977c"
+                "reference": "33bf7454e717101ad42fea63cb32378fee4e6ac6"
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
@@ -709,8 +709,12 @@
                 "zendframework/zend-mvc": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^3.0.1",
-                "phpunit/phpunit": "^10.5.38"
+                "amphp/dns": "^2.4",
+                "amphp/socket": "^2.4",
+                "laminas/laminas-coding-standard": "^3.1",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+                "psalm/plugin-phpunit": "^0.19",
+                "vimeo/psalm": "^6.14"
             },
             "suggest": {
                 "laminas/laminas-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
@@ -773,7 +777,7 @@
                 "chat": "https://laminas.dev/chat",
                 "forum": "https://discourse.laminas.dev"
             },
-            "time": "2026-08-05T01:58:19+00:00"
+            "time": "2026-08-08T15:23:23+00:00"
         },
         {
             "name": "laminas/laminas-router",
@@ -3020,11 +3024,11 @@
         },
         {
             "name": "laminas-api-tools/api-tools-hal",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/datasage/api-tools-hal",
-                "reference": "f19be27edf9fa7b1cad0bda42a02c8f0c512dbbd"
+                "reference": "52844341827428b54dc5918e3c26a8f7c77daefd"
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
@@ -3049,13 +3053,13 @@
                 "zfcampus/zf-hal": "^1.6.0"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^3",
+                "laminas/laminas-coding-standard": "^3.1",
                 "laminas/laminas-router": "^3.16",
                 "phpdocumentor/reflection-docblock": "^5.2.2",
                 "phpspec/prophecy-phpunit": "^2",
-                "phpunit/phpunit": "^10",
+                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
                 "psalm/plugin-phpunit": "^0.19",
-                "vimeo/psalm": "^6.0"
+                "vimeo/psalm": "^6.14"
             },
             "type": "library",
             "extra": {
@@ -3115,7 +3119,7 @@
                 "chat": "https://laminas.dev/chat",
                 "forum": "https://discourse.laminas.dev"
             },
-            "time": "2026-08-05T15:04:20+00:00"
+            "time": "2026-08-08T14:50:04+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -454,34 +454,14 @@
     </ClassMustBeFinal>
     <DeprecatedClass>
       <code><![CDATA[RenameUpload]]></code>
-      <code><![CDATA[RenameUpload]]></code>
-      <code><![CDATA[RenameUpload::class]]></code>
       <code><![CDATA[new RenameUpload($options)]]></code>
     </DeprecatedClass>
-    <DeprecatedInterface>
-      <code><![CDATA[RenameUploadFilterFactory]]></code>
-    </DeprecatedInterface>
-    <DeprecatedMethod>
-      <code><![CDATA[getServiceLocator]]></code>
-    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$container->get('Request')]]></code>
     </MixedArgument>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
     <PossiblyNullArgument>
       <code><![CDATA[$options]]></code>
     </PossiblyNullArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setCreationOptions]]></code>
-    </PossiblyUnusedMethod>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$container->getServiceLocator()]]></code>
-    </RedundantConditionGivenDocblockType>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$requestedName]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Factory/UploadFileValidatorFactory.php">
     <ClassMustBeFinal>
@@ -489,33 +469,11 @@
     </ClassMustBeFinal>
     <DeprecatedClass>
       <code><![CDATA[UploadFile]]></code>
-      <code><![CDATA[UploadFile]]></code>
-      <code><![CDATA[UploadFile::class]]></code>
       <code><![CDATA[new UploadFile($options)]]></code>
     </DeprecatedClass>
-    <DeprecatedInterface>
-      <code><![CDATA[UploadFileValidatorFactory]]></code>
-    </DeprecatedInterface>
-    <DeprecatedMethod>
-      <code><![CDATA[getServiceLocator]]></code>
-      <code><![CDATA[getServiceLocator]]></code>
-    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$container->get('Request')]]></code>
     </MixedArgument>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setCreationOptions]]></code>
-    </PossiblyUnusedMethod>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$container->getServiceLocator()]]></code>
-      <code><![CDATA[$container->getServiceLocator()]]></code>
-    </RedundantConditionGivenDocblockType>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$requestedName]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Filter/RenameUpload.php">
     <ClassMustBeFinal>
@@ -566,9 +524,6 @@
     <DeprecatedMethod>
       <code><![CDATA[entity]]></code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction>
-      <code><![CDATA[false === $serialized]]></code>
-    </DocblockTypeContradiction>
     <ImplementedParamTypeMismatch>
       <code><![CDATA[$variables]]></code>
       <code><![CDATA[$variables]]></code>
@@ -587,7 +542,11 @@
     <MixedAssignment>
       <code><![CDATA[$variables]]></code>
       <code><![CDATA[$variables]]></code>
+      <code><![CDATA[$variables]]></code>
     </MixedAssignment>
+    <MixedReturnStatement>
+      <code><![CDATA[$variables->toJson()]]></code>
+    </MixedReturnStatement>
     <ParamNameMismatch>
       <code><![CDATA[$flag]]></code>
       <code><![CDATA[$flag]]></code>
@@ -1050,6 +1009,9 @@
     <ClassMustBeFinal>
       <code><![CDATA[JsonModelTest]]></code>
     </ClassMustBeFinal>
+    <DeprecatedClass>
+      <code><![CDATA[$jsonModel->setJsonpCallback('callback')]]></code>
+    </DeprecatedClass>
     <InvalidArgument>
       <code><![CDATA[new TestAsset\ModelWithJson()]]></code>
     </InvalidArgument>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -30,12 +30,6 @@
             </errorLevel>
         </RedundantConditionGivenDocblockType>
 
-        <MixedArgumentTypeCoercion>
-            <errorLevel type="suppress">
-                <file name="src/Factory/UploadFileValidatorFactory.php"/>
-            </errorLevel>
-        </MixedArgumentTypeCoercion>
-
         <MoreSpecificImplementedParamType>
             <errorLevel type="suppress">
                 <file name="src/Factory/UploadFileValidatorFactory.php"/>

--- a/src/Factory/AcceptFilterListenerFactory.php
+++ b/src/Factory/AcceptFilterListenerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\AcceptFilterListener;
 use Laminas\ApiTools\ContentNegotiation\ContentNegotiationOptions;
+use Psr\Container\ContainerInterface;
 
 class AcceptFilterListenerFactory
 {

--- a/src/Factory/AcceptListenerFactory.php
+++ b/src/Factory/AcceptListenerFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\AcceptListener;
 use Laminas\ApiTools\ContentNegotiation\ContentNegotiationOptions;
 use Laminas\Mvc\Controller\Plugin\AcceptableViewModelSelector;
+use Psr\Container\ContainerInterface;
 
 class AcceptListenerFactory
 {

--- a/src/Factory/ContentNegotiationOptionsFactory.php
+++ b/src/Factory/ContentNegotiationOptionsFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\ContentNegotiationOptions;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 

--- a/src/Factory/ContentTypeFilterListenerFactory.php
+++ b/src/Factory/ContentTypeFilterListenerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\ContentNegotiationOptions;
 use Laminas\ApiTools\ContentNegotiation\ContentTypeFilterListener;
+use Psr\Container\ContainerInterface;
 
 class ContentTypeFilterListenerFactory
 {

--- a/src/Factory/HttpMethodOverrideListenerFactory.php
+++ b/src/Factory/HttpMethodOverrideListenerFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\ContentNegotiationOptions;
 use Laminas\ApiTools\ContentNegotiation\HttpMethodOverrideListener;
+use Psr\Container\ContainerInterface;
 
 class HttpMethodOverrideListenerFactory
 {

--- a/src/Factory/RenameUploadFilterFactory.php
+++ b/src/Factory/RenameUploadFilterFactory.php
@@ -4,24 +4,15 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\Filter\RenameUpload;
-use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
+use Psr\Container\ContainerInterface;
 
 class RenameUploadFilterFactory implements FactoryInterface
 {
     /**
-     * Required for v2 compatibility.
-     *
-     * @var null|array
-     */
-    private $options;
-
-    /**
-     * @param string $requestedName,
+     * @param string $requestedName
      * @param null|array $options
      * @return RenameUpload
      */
@@ -35,34 +26,5 @@ class RenameUploadFilterFactory implements FactoryInterface
         }
 
         return $filter;
-    }
-
-    /**
-     * Create and return a RenameUpload filter (v2 compatibility)
-     *
-     * @param null|string $name
-     * @param null|string $requestedName
-     * @return RenameUpload
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
-    {
-        $requestedName = $requestedName ?: RenameUpload::class;
-
-        if ($container instanceof AbstractPluginManager) {
-            $container = $container->getServiceLocator() ?: $container;
-        }
-
-        return $this($container, $requestedName, $this->options);
-    }
-
-    /**
-     * Allow injecting options at build time; required for v2 compatibility.
-     *
-     * @return void
-     */
-    public function setCreationOptions(array $options)
-    {
-        $this->options = $options;
     }
 }

--- a/src/Factory/RequestFactory.php
+++ b/src/Factory/RequestFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\Request as HttpRequest;
 use Laminas\Console\Console;
 use Laminas\Console\Request as ConsoleRequest;
+use Psr\Container\ContainerInterface;
 
 use function class_exists;
 

--- a/src/Factory/UploadFileValidatorFactory.php
+++ b/src/Factory/UploadFileValidatorFactory.php
@@ -4,14 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\Validator\UploadFile;
-use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Override;
-
-use function method_exists;
+use Psr\Container\ContainerInterface;
 
 /**
  * @deprecated Will be removed in this fork to reduce dependencies
@@ -19,60 +15,19 @@ use function method_exists;
 class UploadFileValidatorFactory implements FactoryInterface
 {
     /**
-     * Required for v2 compatibility.
-     *
-     * @var null|array
-     */
-    private $options;
-
-    /**
-     * @param string $requestedName,
+     * @param string $requestedName
      * @param array<string, mixed>|null $options
      * @return UploadFile
      */
     #[Override]
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        if (
-            $container instanceof AbstractPluginManager
-            && ! method_exists($container, 'configure')
-        ) {
-            $container = $container->getServiceLocator() ?: $container;
-        }
-
         $validator = new UploadFile($options);
+
         if ($container->has('Request')) {
             $validator->setRequest($container->get('Request'));
         }
+
         return $validator;
-    }
-
-    /**
-     * Create and return an UploadFile validator (v2 compatibility)
-     *
-     * @param null|string $name
-     * @param null|string $requestedName
-     * @return UploadFile
-     */
-    #[Override]
-    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
-    {
-        $requestedName = $requestedName ?: UploadFile::class;
-
-        if ($container instanceof AbstractPluginManager) {
-            $container = $container->getServiceLocator() ?: $container;
-        }
-
-        return $this($container, $requestedName, $this->options);
-    }
-
-    /**
-     * Allow injecting options at build time; required for v2 compatibility.
-     *
-     * @return void
-     */
-    public function setCreationOptions(array $options)
-    {
-        $this->options = $options;
     }
 }

--- a/src/JsonModel.php
+++ b/src/JsonModel.php
@@ -7,10 +7,11 @@ namespace Laminas\ApiTools\ContentNegotiation;
 use JsonSerializable;
 use Laminas\ApiTools\Hal\Collection as HalCollection;
 use Laminas\ApiTools\Hal\Entity as HalEntity;
-use Laminas\Json\Json;
 use Laminas\View\Model\JsonModel as BaseJsonModel;
 use Override;
 
+use function is_object;
+use function json_encode;
 use function json_last_error;
 use function method_exists;
 
@@ -99,17 +100,46 @@ class JsonModel extends BaseJsonModel
             $variables = $variables->getCollection();
         }
 
-        if (null !== $this->jsonpCallback) {
-            return $this->jsonpCallback . '(' . Json::encode($variables) . ');';
-        }
-
-        $serialized = Json::encode($variables);
+        $serialized = $this->encodeVariables($variables);
 
         if (false === $serialized) {
             $this->raiseError(json_last_error());
         }
 
+        if (null !== $this->jsonpCallback) {
+            return $this->jsonpCallback . '(' . $serialized . ');';
+        }
+
         return $serialized;
+    }
+
+    /**
+     * Encode variables as JSON.
+     *
+     * Replaces Laminas\Json\Json::encode(), which is not a thin wrapper around
+     * json_encode(): it gives objects exposing toJson() or toArray() precedence over
+     * native encoding. Both branches are preserved here, because the HAL entity and
+     * collection unwrapped above commonly expose toArray(), and json_encode() would
+     * otherwise serialize their public properties instead.
+     *
+     * Arrays, plain objects and JsonSerializable implementations encode identically
+     * either way, as does escaping.
+     *
+     * @return string|false
+     */
+    private function encodeVariables(mixed $variables)
+    {
+        if (is_object($variables)) {
+            if (method_exists($variables, 'toJson')) {
+                return $variables->toJson();
+            }
+
+            if (method_exists($variables, 'toArray')) {
+                $variables = $variables->toArray();
+            }
+        }
+
+        return json_encode($variables);
     }
 
     /**

--- a/test/Factory/HttpMethodOverrideListenerFactoryTest.php
+++ b/test/Factory/HttpMethodOverrideListenerFactoryTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace LaminasTest\ApiTools\ContentNegotiation\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\ContentNegotiation\ContentNegotiationOptions;
 use Laminas\ApiTools\ContentNegotiation\Factory\HttpMethodOverrideListenerFactory;
 use Laminas\ApiTools\ContentNegotiation\HttpMethodOverrideListener;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
 
 class HttpMethodOverrideListenerFactoryTest extends TestCase
 {

--- a/test/JsonModelTest.php
+++ b/test/JsonModelTest.php
@@ -99,4 +99,42 @@ class JsonModelTest extends TestCase
 
         $this->assertEquals($expected, $data);
     }
+
+    /**
+     * Laminas\Json\Json::encode() gave an object's toArray() precedence over native
+     * encoding. json_encode() would emit the public properties instead, so JsonModel
+     * keeps that branch; this pins it.
+     */
+    public function testSerializesHalEntityExposingToArrayViaToArray(): void
+    {
+        $jsonModel = new JsonModel([
+            'payload' => new HalEntity(new TestAsset\EntityWithToArray(), 'id'),
+        ]);
+
+        $this->assertSame('{"from":"toArray"}', $jsonModel->serialize());
+    }
+
+    /**
+     * toJson() took precedence over toArray() under Laminas\Json\Json::encode(), and its
+     * return value was used verbatim.
+     */
+    public function testSerializesHalEntityExposingToJsonViaToJson(): void
+    {
+        $jsonModel = new JsonModel([
+            'payload' => new HalEntity(new TestAsset\EntityWithToJson(), 'id'),
+        ]);
+
+        $this->assertSame('{"from":"toJson"}', $jsonModel->serialize());
+    }
+
+    /**
+     * The jsonp callback wraps the same encoded payload the plain path produces.
+     */
+    public function testJsonpCallbackWrapsTheEncodedPayload(): void
+    {
+        $jsonModel = new JsonModel(['some' => 'content']);
+        $jsonModel->setJsonpCallback('callback');
+
+        $this->assertSame('callback({"some":"content"});', $jsonModel->serialize());
+    }
 }

--- a/test/TestAsset/EntityWithToArray.php
+++ b/test/TestAsset/EntityWithToArray.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\ApiTools\ContentNegotiation\TestAsset;
+
+/**
+ * An entity exposing toArray(), which is the common shape inside a HAL entity.
+ *
+ * Laminas\Json\Json::encode() gave toArray() precedence over native encoding, so
+ * JsonModel preserves that branch; without it the public property would be serialized
+ * instead of the toArray() payload.
+ */
+class EntityWithToArray
+{
+    public string $publicProperty = 'from-property';
+
+    /** @return array<string, string> */
+    public function toArray(): array
+    {
+        return ['from' => 'toArray'];
+    }
+}

--- a/test/TestAsset/EntityWithToJson.php
+++ b/test/TestAsset/EntityWithToJson.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\ApiTools\ContentNegotiation\TestAsset;
+
+/**
+ * An entity exposing toJson(), which Laminas\Json\Json::encode() returned verbatim and
+ * in preference to toArray() or native encoding. JsonModel preserves that precedence.
+ */
+class EntityWithToJson
+{
+    public string $publicProperty = 'from-property';
+
+    /** @return array<string, string> */
+    public function toArray(): array
+    {
+        return ['from' => 'toArray'];
+    }
+
+    public function toJson(): string
+    {
+        return '{"from":"toJson"}';
+    }
+}


### PR DESCRIPTION
## Summary

Two backlog items that turned out to be entangled, plus a third dependency that fell out of them.

> ⚠️ **This is a BC break.** `createService()` and `setCreationOptions()` were public, so the next release from this line is a **major**, not a patch. See the end.

## laminas-json

`JsonModel::serialize()` was the only consumer, via two `Json::encode()` calls.

**`Json::encode()` is not a thin wrapper around `json_encode()`** — it gives objects exposing `toJson()` or `toArray()` precedence over native encoding. That difference is live here: `serialize()` unwraps a HAL entity or collection first, and those commonly expose `toArray()`. A naive swap would have serialized their *public properties* instead.

Measured before changing anything:

| case | `Json::encode` | `json_encode` | |
| --- | --- | --- | --- |
| array | `{"a":1}` | `{"a":1}` | same |
| **object `toArray`** | `{"from":"toArray"}` | `{"keep":1}` | **differs** |
| **object `toJson`** | `{"from":"toJson"}` | `{"keep":1}` | **differs** |
| plain object | `{"keep":1}` | `{"keep":1}` | same |
| `JsonSerializable` | `{"from":"jsonSerialize"}` | `{"from":"jsonSerialize"}` | same |
| slashes + unicode | `{"u":"\/pathé"}` | `{"u":"\/pathé"}` | same |

So `encodeVariables()` keeps both branches and delegates the rest to `json_encode()`. **Three characterization tests pin the precedence** — `toArray`, `toJson` over `toArray`, and the jsonp wrapper — using two new test assets.

Encoding now happens **once** rather than twice, and the jsonp path wraps that result. That also makes the existing `false === $serialized` guard meaningful again: `Json::encode()` *threw* rather than returning `false`, so the check had been dead — and the jsonp path skipped it entirely.

`laminas-json` stays in the installed tree because `laminas-view` requires it, but it's no longer a direct dependency of this package.

## ServiceManager v2

`RenameUploadFilterFactory` and `UploadFileValidatorFactory` each carried the full v2 surface:

- `createService()`
- `setCreationOptions()` and the private `$options` field that existed to carry those options
- the v2 `FactoryInterface` and `ServiceLocatorInterface`
- in `UploadFileValidatorFactory`, a branch on whether an `AbstractPluginManager` had a `configure()` method — which only ever distinguished v2 from v3

All of it is gone. Both now implement `Laminas\ServiceManager\Factory\FactoryInterface` and do only what v3 asks.

**Nothing internal used the v2 API**: `config/module.config.php` registers both as ordinary v3 factories, and no test calls `createService()` or `setCreationOptions()`.

## container-interop — an unplanned third removal

The v3 `FactoryInterface` types its container as `Psr\Container\ContainerInterface`, so the two factories *had* to move off `Interop\Container\ContainerInterface`. Six other `src/` files and one test used it too, and migrating all eight drops **`container-interop/container-interop`** — abandoned — from the requirements entirely. Confirmed uninstalled afterwards.

Interop's interface *extends* the PSR one, so this **widens** the parameter type rather than narrowing it. `psr/container ^1.1 || ^2.0` is now declared directly, since `src/` references it.

Also removed the psalm `MixedArgumentTypeCoercion` suppression for `UploadFileValidatorFactory`, which stopped triggering once the v2 branch went.

## Verification

**161 tests, 377 assertions green on phpunit 11.5.50 through 13.1.14, across 8.2 and 8.5.** psalm and phpcs clean on the locked set; baseline regenerated cold on 8.2.

## Versioning

Merging this makes the next tag from `1.11.x` a **2.0.0**. Worth noting the existing `2.0.x` branch is stale — 6 commits behind, predating the 8.5 sweep and both cleanup cycles — and its only unique content is the `removeDeprecated` work, which overlaps this change (`RenameUploadFilterFactory` is one of the two factories here). Suggest retiring it in favour of a 2.0 line cut from this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved JSON serialization for objects providing custom array or JSON representations.
  * Added clearer handling of JSON encoding errors before JSONP responses are generated.
  * JSONP callback output now preserves the encoded payload correctly.

* **Compatibility**
  * Updated service factories to use the current PSR container standard.
  * Removed legacy factory compatibility behavior, simplifying integration with modern service managers.

* **Tests**
  * Added coverage for custom entity serialization and JSONP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->