### PR TITLE
Widen sibling constraints to allow the coming majors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laminas-api-tools/api-tools-api-problem": "^1.10",
         "laminas/laminas-eventmanager": "^3.15",
         "laminas/laminas-http": "^2.23 || ^3.0",
-        "laminas/laminas-mvc": "^3.8",
+        "laminas/laminas-mvc": "^3.8 || ^4.0",
         "laminas/laminas-servicemanager": "^3.24",
         "laminas/laminas-stdlib": "^3.21",
         "laminas/laminas-view": "^2.43",
@@ -43,7 +43,7 @@
         "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
-        "laminas-api-tools/api-tools-hal": "^1.13",
+        "laminas-api-tools/api-tools-hal": "^1.13 || ^2.0",
         "laminas/laminas-coding-standard": "^3.1",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4f0aed2301742b8d152e06548e46b49",
+    "content-hash": "0b5cb7061d9d343ef4c79e7ea2aa1170",
     "packages": [
         {
             "name": "brick/varexporter",


### PR DESCRIPTION
Preparation for the coordinated major release across the forks. Ten forks carry merged BC-breaking work and are about to be tagged:

| fork | new major |
| --- | --- |
| api-tools | 2.0.0 |
| api-tools-content-negotiation | 2.0.0 |
| api-tools-content-validation | 2.0.0 |
| api-tools-hal | 2.0.0 |
| api-tools-mvc-auth | 2.0.0 |
| api-tools-rest | 2.0.0 |
| api-tools-rpc | 2.0.0 |
| api-tools-doctrine | 4.0.0 |
| laminas-mvc | 4.0.0 |
| laminas-modulemanager | 3.0.0 |

Every fork constrains its siblings with `^1.x`-style ranges, so without this the new majors would be uninstallable — composer would keep resolving the old line. This adds the new major as an alternative arm (`^1.10 || ^2.0`) rather than replacing anything, so nothing changes for existing consumers.

**This must land before the tags**, because the widened constraints have to be present in the tagged commit.

## Why it is safe to land before the majors exist

A fork's own CI resolves **upstream** packages: composer honours a `repositories` entry only in the **root** package, so from this repo's perspective there is no `laminas/laminas-mvc` 4.x or `laminas-api-tools/api-tools-*` 2.x to find, and the new arm is inert. Only the primary consuming application, which carries the `repositories` entries, can resolve them. This is the same pattern used when `datasage/laminas-http` 3.0.0 was adopted and thirteen forks were widened to `^2.23 || ^3.0`.

## Verification

`composer update --lock` (hash refresh only — the lock diff is exactly one line, `content-hash`), then `composer install` and the full gate set on this repo's floor PHP against the committed lock: phpunit, psalm and phpcs all as before the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported dependency versions for improved compatibility with newer Laminas MVC and API Tools HAL releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
